### PR TITLE
Trimming innerHTML and expected output

### DIFF
--- a/src/modify.spec.js
+++ b/src/modify.spec.js
@@ -111,7 +111,7 @@ describe(testSuiteName, () => {
 
   it('Add the bio content to the page', () => {
     const bioEl = document.querySelector('#my-bio');
-    expect(bioEl.innerHTML).toBe(`
+    const expectedOutput = `
     <h2 id="bio-heading">About Me</h2>
     <p>My name is Zo and I like learn cool new things</p>
     <h3 id="hobby-heading">My Hobbies</h3>
@@ -119,7 +119,9 @@ describe(testSuiteName, () => {
       <li>Running</li>
       <li>Reading</li>
       <li>Writing</li>
-    </ul>`);
+    </ul>
+    `
+    expect(bioEl.innerHTML.trim()).toBe(expectedOutput.trim());
 
     scoreCounter.correct(expect); // DO NOT TOUCH
   });


### PR DESCRIPTION
Many fellows have failed this test because this test is VERY strict about spacing. While I think indentation of the elements is important, the spacing before the h2 and after the ul is arbitrary. Unless we are teaching some sort of best practice for using string templates, or if we really want to force fellows to look at the tests (in which case they'd just see the answer anyway), there's no need for this test to be as strict as it is.

A better test would check the structure of the `bioEl` Node by Node but I'm guessing that would be more than what you want to do.